### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For browser and universal project:
 yarn add --dev @logux/eslint-config eslint-config-standard eslint-plugin-promise eslint-plugin-jest eslint-plugin-node eslint-plugin-es5 eslint-plugin-standard eslint-plugin-security eslint-plugin-import eslint-plugin-import-helpers eslint
 ```
 
-For server-only project you can use config with ES2015+ support:
+For the server-only project you can use config with ES2015+ support:
 
 ```sh
 yarn add --dev @logux/eslint-config eslint-config-standard eslint-plugin-promise eslint-plugin-jest eslint-plugin-node eslint-plugin-standard eslint-plugin-security eslint-plugin-import eslint-plugin-import-helpers eslint-plugin-prefer-let eslint
@@ -23,7 +23,7 @@ yarn add --dev @logux/eslint-config eslint-config-standard eslint-plugin-promise
 
 ## Usage
 
-Add this config to `package.json` or other ESLint config.
+Add this config to `package.json` or other ESLint configs.
 
 Browser and universal project:
 
@@ -37,6 +37,6 @@ Server-only project:
 
 ```sh
   "eslintConfig": {
-    "extends": "@logux/eslint-config-logux/node"
+    "extends": "@logux/eslint-config/node"
   }
 ```


### PR DESCRIPTION
Hi, @ai!

Thank you for the great config, I use it in any my project.

I tried to add these rules to my new project but with no success. It was found that there is a typo in README: looks like `"@logux/eslint-config-logux/node"` is deprecated package name.

Thanks!