### PR TITLE
fix import/extensions for typescript

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -79,7 +79,11 @@ module.exports = {
         ],
         '@typescript-eslint/array-type': 'error',
 
-        'import/extensions': ['error', 'always', { ignorePackages: true }],
+        'import/extensions': [
+          'error',
+          'ignorePackages',
+          { js: 'never', jsx: 'never', ts: 'never', tsx: 'never' }
+        ]
 
         'lines-between-class-members': 'off',
         'no-useless-constructor': 'off',

--- a/ts.js
+++ b/ts.js
@@ -83,7 +83,7 @@ module.exports = {
           'error',
           'ignorePackages',
           { js: 'never', jsx: 'never', ts: 'never', tsx: 'never' }
-        ]
+        ],
 
         'lines-between-class-members': 'off',
         'no-useless-constructor': 'off',


### PR DESCRIPTION
eslint-plugin-import still shows `without an extension` error for importing typescript. But typescript showing ts(2691) error for 
```import { Button } from '../../components/button/Button.tsx'```
